### PR TITLE
Modified upload.js to accept gulp streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,18 @@ npm install gulp-azure-storage
 ## Usage
 
 ### Upload
+Simply pipe in a gulp stream:
 
-There's a script included with the module that allows you to upload some files to an azure container:
-
-```bash
-$ ./node_modules/.bin/upload-to-azure \
-  --account ACCOUNT_NAME \
-  --key ACCOUNT_KEY \
-  --container CONTAINER_NAME \
-  file1.txt \
-  file2.txt
+```javascript
+gulp.task(['default'], function() { 
+  return gulp.src('path')
+    .pipe(azure.upload({
+    	account:    ACCOUNT_NAME,
+    	key:        ACCOUNT_KEY,
+    	container:  CONTAINER_NAME
+    }));
+});
 ```
-
-You can also provide a **relative** folder to upload every file in that folder structure, instead of every file, one by one:
-
-```bash
-$ ./node_modules/.bin/upload-to-azure \
-  --account ACCOUNT_NAME \
-  --key ACCOUNT_KEY \
-  --container CONTAINER_NAME \
-  folder
-```
-
 ### Download
 
 Simply use it as a gulp source stream:
@@ -43,7 +33,7 @@ var gulp = require('gulp');
 var azure = require('gulp-azure-storage');
 
 gulp.task(['default'], function() {
-  return azure({
+  return azure.download({
   	account:    ACCOUNT_NAME,
   	key:        ACCOUNT_KEY,
   	container:  CONTAINER_NAME
@@ -61,4 +51,4 @@ Mandatory:
 Optional:
 - `prefix` - blob name prefix
 - `quiet` - shhh
-- `buffer` - `boolean` for whether to buffer the blobs or stream them
+- `buffer` - `boolean` for whether to buffer the blobs or stream them (only for download)

--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
-module.exports = require('./lib/download');
+module.exports.download = require('./lib/download');
+module.exports.upload = require('./lib/upload');

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -32,7 +32,7 @@ module.exports = function (opts) {
 			var that = this;
 			service.createContainerIfNotExists(opts.container, function (err) {
 				if (err) { that.emit('error', err); }
-				if (!opts.quiet) {
+				if (!opts.quiet && q.length > 0) {
 					var bar = new ProgressBar('uploading [:bar] :percent', { total: q.length });
 					bar.tick(0);
 					q.on('success', function () { bar.tick(); });

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -4,36 +4,43 @@ var queue = require('queue');
 var ProgressBar = require('progress');
 var vfs = require('vinyl-fs');
 
-module.exports = function (account, key, container, prefix, filePaths, callback) {
-	prefix = prefix ? prefix.replace(/\/+$/, '') + '/' : '';
-	var service = azure.createBlobService(account, key);
+module.exports = function (opts) {
+	if (!opts.account) {
+		throw new Error('Missing account option.');
+	}
 
-	service.createContainerIfNotExists(container, function (err) {
-		if (err) { return callback(err); }
+	if (!opts.key) {
+		throw new Error('Missing key option.');
+	}
 
-		var q = queue({ concurrency: 4, timeout: 1000 * 60 * 2 });
+	if (!opts.container) {
+		throw new Error('Missing container option.');
+	}
 
-		vfs
-			.src(filePaths.map(function(arg) { return arg + '/**/*'; }))
-			.pipe(es.through(function (data) {
-				if (data.contents) {
-					q.push(function (cb) {
-						service.createBlockBlobFromLocalFile(container, prefix + data.relative, data.path, {
-							metadata: {
-								fsmode: data.stat.mode
-							}
-						}, cb);
-					});
+	opts.prefix = opts.prefix | '';
+	var service = azure.createBlobService(opts.account, opts.key);
+	var q = queue({ concurrency: 5, timeout: 1000 * 60 * 2 });
+	
+	var stream = es.through(function(data) {
+		q.push(function(cb) {
+			service.createBlockBlobFromLocalFile(opts.container, opts.prefix + data.relative, data.path, {
+				metadata: {
+					fsmode: data.stat.mode
 				}
-		  }, function () {
-		  	var that = this;
-				var bar = new ProgressBar('uploading [:bar] :percent', { total: q.length });
-				bar.tick(0);
-
-				q.on('success', function () { bar.tick(); });
+			}, cb);
+		})}, function () {
+			var that = this;
+			service.createContainerIfNotExists(opts.container, function (err) {
+				if (err) { that.emit('error', err); }
+				if (!opts.quiet) {
+					var bar = new ProgressBar('uploading [:bar] :percent', { total: q.length });
+					bar.tick(0);
+					q.on('success', function () { bar.tick(); });
+				}
 				q.on('error', function (err) { that.emit('error', err); });
-		  	q.start(function () { that.emit('end'); });
-		  }))
-		  .on('end', function () { callback(); });
-	});
+				q.start(function () { that.emit('end'); });
+			});
+		}).on('end', function () { });
+	
+	return stream;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-azure-storage",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Gulp plugin to download and upload files to/from the Azure blob storage",
   "main": "index.js",
   "author": "João Moreno",


### PR DESCRIPTION
Upload.js now accepts gulp streams. Updated index.js to export both upload and download.
Bumped version in package.json to 0.1.0 to signify a breaking change.
Updated README to reflect changes.
