### PR TITLE
fix upload to azure

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -12,27 +12,45 @@ module.exports = function (opts) {
 	if (!opts.container) {
 		throw new Error('Missing container option.');
 	}
-	
+
 	var prefix = opts.prefix || '';
-	
+
 	var service = azure.createBlobService(opts.account, opts.key).withFilter(new azure.LinearRetryPolicyFilter());
 	var q = queue({ concurrency: 4, timeout: 1000 * 60 * 2 });
-	
+
 	var count = 0;
 	var stream = es.through(function(file) {
+		var that = this;
 		if (file.isDirectory()) {
 			return;
 		}
-		
+
 		q.push(function(cb) {
-			service.createBlockBlobFromLocalFile(opts.container, prefix + file.relative, file.path, {
-				metadata: { fsmode: file.stat.mode }
-			}, cb);
+			if (file.isBuffer()) {
+				service.createBlockBlobFromText(opts.container, prefix + file.relative, file.contents.toString(), {
+						metadata: { fsmode: file.stat.mode }
+					}, function(error) {
+						if (!error) {
+							that.push(file);
+						}
+						cb(error);
+				});
+			} else if (file.isStream()) {
+				var stream = service.createWriteStreamToBlockBlob(opts.container, prefix + file.relative, {
+						metadata: { fsmode: file.stat.mode }
+					}, function(error) {
+						if (!error) {
+							that.push(file);
+						}
+						cb(error);
+				});
+				file.contents = file.contents.pipe(stream);
+			}
 		})}, function () {
 			var that = this;
 			service.createContainerIfNotExists(opts.container, function (err) {
 				if (err) { that.emit('error', err); }
-				
+
 				if (!opts.quiet && q.length > 0) {
 					var bar = new ProgressBar('uploading [:bar] :percent', { total: q.length });
 					bar.tick(0);
@@ -41,17 +59,17 @@ module.exports = function (opts) {
 						bar.tick();
 					});
 				}
-				
+
 				q.on('error', function (err) { that.emit('error', err); });
 				q.start(function () {
 					if (!opts.quiet) {
 						console.log(count + ' files uploaded.');
 					}
-					
+
 					that.emit('end');
 				});
 			});
 		});
-	
+
 	return stream;
 };

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -12,19 +12,15 @@ module.exports = function (opts) {
 	if (!opts.container) {
 		throw new Error('Missing container option.');
 	}
-
 	var prefix = opts.prefix || '';
-
 	var service = azure.createBlobService(opts.account, opts.key).withFilter(new azure.LinearRetryPolicyFilter());
 	var q = queue({ concurrency: 4, timeout: 1000 * 60 * 2 });
-
 	var count = 0;
 	var stream = es.through(function(file) {
 		var that = this;
 		if (file.isDirectory()) {
 			return;
 		}
-
 		q.push(function(cb) {
 			if (file.isBuffer()) {
 				service.createBlockBlobFromText(opts.container, prefix + file.relative, file.contents.toString(), {
@@ -50,7 +46,6 @@ module.exports = function (opts) {
 			var that = this;
 			service.createContainerIfNotExists(opts.container, function (err) {
 				if (err) { that.emit('error', err); }
-
 				if (!opts.quiet && q.length > 0) {
 					var bar = new ProgressBar('uploading [:bar] :percent', { total: q.length });
 					bar.tick(0);
@@ -59,17 +54,14 @@ module.exports = function (opts) {
 						bar.tick();
 					});
 				}
-
 				q.on('error', function (err) { that.emit('error', err); });
 				q.start(function () {
 					if (!opts.quiet) {
 						console.log(count + ' files uploaded.');
 					}
-
 					that.emit('end');
 				});
 			});
 		});
-
 	return stream;
 };


### PR DESCRIPTION
This PR address an issue where node was throwing out of memory exceptions due double reading of file between gulp and azure SDK. I also added a couple more fixes. 

What this PR does: 
1- Uses createBlockBlobFromText instead of createBlockBlobFromFile to address the memory problem 
2- Pushes back the files through the stream so other modules can be piped after. (I think this was a bug?)
3- Add support for streams
