### PR TITLE
fix mime bug

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -4,7 +4,6 @@ var queue = require('queue');
 var ProgressBar = require('progress');
 var vfs = require('vinyl-fs');
 var createReadStream = require('streamifier').createReadStream;
-var azureutil = require('azure-storage/lib/common/common').util;
 var mime = require('mime');
 
 module.exports = function (opts) {
@@ -27,15 +26,11 @@ module.exports = function (opts) {
 		}
 
 		q.push(function(cb) {
-			var options = { metadata: { fsmode: file.stat.mode }}
-            		if(azureutil.tryGetValueChain(options, ['contentSettings','contentType'], undefined) === undefined) {
-                		azureutil.setObjectInnerPropertyValue(options, ['contentSettings','contentType'], mime.lookup(file.relative));
-            		}
 			var istream = file.isBuffer() ? createReadStream(file.contents) : file.contents;
 			var ostream = service.createWriteStreamToBlockBlob(
 				opts.container,
 				prefix + file.relative,
-				options,
+				{ metadata: { fsmode: file.stat.mode }, contentSettings: {contentType: mime.lookup(file.relative)}},
 				function(err) {
 					if (err) { return cb(err); }
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -4,6 +4,7 @@ var queue = require('queue');
 var ProgressBar = require('progress');
 var vfs = require('vinyl-fs');
 var createReadStream = require('streamifier').createReadStream;
+var azureutil = require('azure-storage/lib/common/common').util;
 var mime = require('mime');
 
 module.exports = function (opts) {
@@ -26,11 +27,15 @@ module.exports = function (opts) {
 		}
 
 		q.push(function(cb) {
+			var options = { metadata: { fsmode: file.stat.mode }}
+            		if(azureutil.tryGetValueChain(options, ['contentSettings','contentType'], undefined) === undefined) {
+                		azureutil.setObjectInnerPropertyValue(options, ['contentSettings','contentType'], mime.lookup(file.relative));
+            		}
 			var istream = file.isBuffer() ? createReadStream(file.contents) : file.contents;
 			var ostream = service.createWriteStreamToBlockBlob(
 				opts.container,
 				prefix + file.relative,
-				{ metadata: { fsmode: file.stat.mode }, contentType: mime.lookup(file.relative) },
+				options,
 				function(err) {
 					if (err) { return cb(err); }
 


### PR DESCRIPTION
We are using this module and found mime type not correct, so correct the code like the code of blobservice.js in 'azure-storage' module. The option should be { metadata: { fsmode:fsmode},contentSettings: { contentType: contentType } }
